### PR TITLE
Feature/anonmode

### DIFF
--- a/doc/README_QUICKSTART.md
+++ b/doc/README_QUICKSTART.md
@@ -21,6 +21,17 @@ bluetack $ sudo python3 -m pip install --upgrade pip
 bluetack $ sudo python3 -m pip install taky
 [...]
 
+# Short on time? Run servernow.sh
+If you are not interested in understanding certificates but just want a server now, run the ./servernow.sh script located in ./taky/util/servernow.sh.
+
+This will generate 10 year certificates, an SSL server config and an IP based (vs domain name based) server in /tmp/takyserver listening on SSL :8089
+The .zip data package(s) for clients will be offered via a web server on TCP:1664 for a 15 minute window. If you miss the provisioning window you can sideload the .zip.
+
+To add a client in ATAK, click "Import Manager" then "HTTP URL" and enter the http:// URL for your .zip which will be shown in the console.
+
+Download the .zip and expect to see a red "server disconnected" icon appear.
+Visit settings > Network connections and enable the server by checking the box.
+
 # Generate config + CA + Certs
 bluetack $ sudo takyctl setup --host <hostname> --public-ip 123.45.67.89 --user bluetack
 Installing site to system

--- a/doc/README_QUICKSTART.md
+++ b/doc/README_QUICKSTART.md
@@ -1,8 +1,23 @@
+
+# Do you need a server *now*?
+If you are not interested in manually creating certificates **but want a server now**, run the ./servernow.sh script located in ./taky/util/servernow.sh.
+
+This will generate 10 year certificates, an SSL server config with mutual authentication and an IP based (vs domain name based) server in /tmp/takyserver listening on SSL :8089
+
+The .zip data package(s) for clients will be offered via a web server on TCP:1664 for a 15 minute window. *If you miss the provisioning window you can sideload the .zip.*
+
+To add a client in ATAK, click "Import Manager" then "HTTP URL" and enter the http:// URL for your .zip which will be shown in the console.
+
+Download the .zip and expect to see a red "server disconnected" icon appear.
+Visit settings > Network connections and enable the server by checking the box.
+
+[2 minute TAK server on Youtube](https://www.youtube.com/watch?v=SRpU5w6VgDY)
+
 # Shut up and take my money!
 
 Ok, geez! Hold your horses! This guide assumes:
 
-1. You have sudo privilegs
+1. You have sudo privileges
 2. You don't mind installing things globally
 3. You don't want to run the server as root
 4. You want SSL, and know how to get files to your end user devices
@@ -20,17 +35,6 @@ bluetack $ sudo python3 -m pip install --upgrade pip
 # Install taky
 bluetack $ sudo python3 -m pip install taky
 [...]
-
-# Short on time? Run servernow.sh
-If you are not interested in understanding certificates but just want a server now, run the ./servernow.sh script located in ./taky/util/servernow.sh.
-
-This will generate 10 year certificates, an SSL server config and an IP based (vs domain name based) server in /tmp/takyserver listening on SSL :8089
-The .zip data package(s) for clients will be offered via a web server on TCP:1664 for a 15 minute window. If you miss the provisioning window you can sideload the .zip.
-
-To add a client in ATAK, click "Import Manager" then "HTTP URL" and enter the http:// URL for your .zip which will be shown in the console.
-
-Download the .zip and expect to see a red "server disconnected" icon appear.
-Visit settings > Network connections and enable the server by checking the box.
 
 # Generate config + CA + Certs
 bluetack $ sudo takyctl setup --host <hostname> --public-ip 123.45.67.89 --user bluetack
@@ -72,6 +76,7 @@ $ python3 -m http.server
 Serving HTTP on 0.0.0.0 port 8000 (http://0.0.0.0:8000/) ...
 ```
 
+
 ## I want to delete everything and start over!
 
 Pretty simple.
@@ -89,3 +94,4 @@ Then, delete all the config and user data.
 ```
 root # rm -rf /etc/taky /var/taky
 ```
+

--- a/doc/README_SECURITY.md
+++ b/doc/README_SECURITY.md
@@ -112,6 +112,20 @@ We could implement a revocation list to lock them out of further access, but
 they will still have access to the server until then. Perhaps this is a feature for
 later.
 
+## Anonymous mode
+
+If you want to host a public server so people can get access to your network plugins you might not want strangers popping up on the map or in the chat. To make your server anonymous, set hide_strangers = True
+To enable some users to show up, enter their device UID in the show_uids list.
+ 
+```
+[cot_server]
+port = 8089
+log_cot
+hide_strangers = True
+show_uids = ["ANDROID-1234"]
+```
+
+
 ## The Conclusion of the Matter?
 
 Ooog. Use a VPN and control access tightly. Regenerate your CA and certificates

--- a/taky/cli/build_client_cmd.py
+++ b/taky/cli/build_client_cmd.py
@@ -92,8 +92,9 @@ def build_client(config, args):
         shutil.copy(os.path.join(cdir, f"{args.name}.crt"), cwd)
         shutil.copy(os.path.join(cdir, f"{args.name}.key"), cwd)
 
-        os.unlink(os.path.join(cdir, f"{args.name}.crt"))
-        os.unlink(os.path.join(cdir, f"{args.name}.key"))
+	# Need these for other clients
+        #os.unlink(os.path.join(cdir, f"{args.name}.crt"))
+        #os.unlink(os.path.join(cdir, f"{args.name}.key"))
 
     # Save temporary directory, and build ZIP file
     os.chdir(tdir)

--- a/taky/cli/build_client_cmd.py
+++ b/taky/cli/build_client_cmd.py
@@ -70,7 +70,7 @@ def build_client(config, args):
         },
     }
 
-    with open(os.path.join(cdir, "fts.pref"), "wb") as pref_fp:
+    with open(os.path.join(cdir, "taky.pref"), "wb") as pref_fp:
         datapackage.build_pref(pref_fp, prefs)
 
     # Build Mission Package Manifest
@@ -79,7 +79,7 @@ def build_client(config, args):
         "name": f"{hostname}_DP",
         "onReceiveDelete": "true",
     }
-    man_cts = ["fts.pref", os.path.basename(server_p12), f"{args.name}.p12"]
+    man_cts = ["taky.pref", os.path.basename(server_p12), f"{args.name}.p12"]
 
     with open(os.path.join(mdir, "manifest.xml"), "wb") as man_fp:
         datapackage.build_manifest(man_fp, cfg_params, man_cts)

--- a/taky/cli/setup_taky_cmd.py
+++ b/taky/cli/setup_taky_cmd.py
@@ -66,13 +66,13 @@ def setup_taky(config, args):
         ssl_path = "ssl"
         config_path = "taky.conf"
 
-        config.set("ssl", "ca", os.path.join(".", "ssl", "ca.crt"))
-        config.set("ssl", "ca_key", os.path.join(".", "ssl", "ca.key"))
-        config.set("ssl", "server_p12", os.path.join(".", "ssl", "server.p12"))
-        config.set("ssl", "cert", os.path.join(".", "ssl", "server.crt"))
-        config.set("ssl", "key", os.path.join(".", "ssl", "server.key"))
+        config.set("ssl", "ca", os.path.join(args.path, "ssl", "ca.crt"))
+        config.set("ssl", "ca_key", os.path.join(args.path, "ssl", "ca.key"))
+        config.set("ssl", "server_p12", os.path.join(args.path, "ssl", "server.p12"))
+        config.set("ssl", "cert", os.path.join(args.path, "ssl", "server.crt"))
+        config.set("ssl", "key", os.path.join(args.path, "ssl", "server.key"))
 
-        config.set("dp_server", "upload_path", os.path.join(".", "dp-user"))
+        config.set("dp_server", "upload_path", os.path.join(args.path, "dp-user"))
     else:
         print("Installing site to system")
         args.path = "/"

--- a/taky/cli/setup_taky_cmd.py
+++ b/taky/cli/setup_taky_cmd.py
@@ -96,6 +96,8 @@ def setup_taky(config, args):
     config.set("taky", "public_ip", args.public_ip)
     config.set("taky", "hostname", args.hostname)
     config.set("cot_server", "port", "8089" if args.use_ssl else "8087")
+    config.set("cot_server", "hide_strangers", "False")
+    config.set("cot_server", "show_uids", "[]")
     config.set("ssl", "enabled", "true" if args.use_ssl else "false")
     config.set("ssl", "server_p12_pw", args.p12_pw)
 

--- a/taky/util/dpserver.py
+++ b/taky/util/dpserver.py
@@ -1,0 +1,41 @@
+#!/usr/bin/python3
+from flask import Flask, request, send_from_directory
+import sys
+import os
+import socket
+import random
+
+# Serves certificates from /tmp/taky_dp
+# eg. http://192.168.1.107:1664/5036307/user_DP.zip
+
+app = Flask(__name__, static_url_path='')
+port = 1664
+
+if len(sys.argv) < 2:
+  print("Need a directory to serve up. eg. dpserver.py /tmp/somedir")
+  quit()
+
+webroot = os.path.join(os.getcwd(), sys.argv[1])
+
+if not os.path.exists(webroot):
+  print("Folder %s does not exist" % webroot)
+  quit()
+
+
+nonce = "takycerts" # str(random.randrange(1e6,10e6)) # Make URL harder to guess 
+
+@app.route("/"+nonce+"/<path>")
+def send_js(path):
+    return send_from_directory(webroot, path)
+  
+
+if __name__ == "__main__":
+    print("\nWARNING: Serving certificates insecurely from %s" % webroot)
+    files = os.listdir(webroot)
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.connect(("8.8.8.8", 53)) # to resolve our external IP. Doesn't have to be reachable.
+    ip = s.getsockname()[0]
+    for f in files:
+      print("http://%s:%d/%s/%s" % (ip,port,nonce,f))
+
+    app.run(host="0.0.0.0",port=port)

--- a/taky/util/servernow.sh
+++ b/taky/util/servernow.sh
@@ -7,7 +7,7 @@ IP=`ifconfig $NIC | grep 'inet ' | awk '{print $2}'`
 TAKY_SERVER="/tmp/takyserver"
 
 takyctl setup --public-ip $IP --host $IP $TAKY_SERVER
-takyctl -c $TAKY_SERVER/taky.conf build_client user
+takyctl -c $TAKY_SERVER/taky.conf build_client --dump_pem user
 mkdir $TAKY_SERVER/taky_dp
 cp user.zip $TAKY_SERVER/taky_dp
 

--- a/taky/util/servernow.sh
+++ b/taky/util/servernow.sh
@@ -13,6 +13,6 @@ cp user.zip $TAKY_SERVER/taky_dp
 
 # Comment this line to NOT serve your certificates insecurely via HTTP :1664
 # It will serve the certs for 15 minutes only. After that you need to sideload the .zip
-timeout 15m dpserver.py $TAKY_SERVER/taky_dp &
+timeout 15m python3 dpserver.py $TAKY_SERVER/taky_dp &
 taky -c $TAKY_SERVER/taky.conf
 

--- a/taky/util/servernow.sh
+++ b/taky/util/servernow.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# 
+# Builds a secure taky server now, not next week.
+
+NIC=`route -n | grep '0.0.0.0' | head -1 |  awk '{print $8}'`
+IP=`ifconfig $NIC | grep 'inet ' | awk '{print $2}'`
+TAKY_SERVER="/tmp/takyserver"
+
+takyctl setup --public-ip $IP --host $IP $TAKY_SERVER
+takyctl -c $TAKY_SERVER/taky.conf build_client user
+mkdir $TAKY_SERVER/taky_dp
+cp user.zip $TAKY_SERVER/taky_dp
+
+# Comment this line to NOT serve your certificates insecurely via HTTP :1664
+# It will serve the certs for 15 minutes only. After that you need to sideload the .zip
+timeout 15m dpserver.py $TAKY_SERVER/taky_dp &
+taky -c $TAKY_SERVER/taky.conf
+


### PR DESCRIPTION
- Added two new config options to firewall strangers "hide_strangers" and "show_uids"
- UID checks in router.py to avert "stranger danger"
- Added dump_pem to servernow.sh script to retain user.crt for non ATAK clients eg. bots
- Updated security doc

Testing this requires disabling multicast sharing of positions otherwise it looks like it's not working.
The uids in show_uids will appear in geochat and can be interacted with but others will be invisible and cannot chat through this server when enabled...