### PR TITLE
Data Package Privacy - respect the `tool` setting that ATAK sets on upload

### DIFF
--- a/taky/dps/views/datapackage.py
+++ b/taky/dps/views/datapackage.py
@@ -144,7 +144,7 @@ def datapackage_upload():
         "Keywords": "kw",
         "MIMEType": asset_fp.mimetype,
         "Size": os.path.getsize(file_path),  # Checked, do not fake
-        "Visibility": "public"
+        "Visibility": "private"
     }
 
     # Save the file's meta/{filename}.json
@@ -173,9 +173,9 @@ def datapackage_metadata_tool(f_hash):
     if not meta:
         return f"Could not find file matching {f_hash}", 404
 
-    visibility = "private" if request.get_data().decode("utf-8") == "private" else "public"
+    visibility = "public" if request.get_data().decode("utf-8") == "public" else "private"
 
-    if meta.get("Visibility", "public") != visibility:
+    if meta.get("Visibility", "private") != visibility:
         meta["Visibility"] = visibility
         put_meta(meta)
 


### PR DESCRIPTION
If you send a package directly to the server, it will be set to "public"
and will show in the listing of available files.
If you send a packages to another user via the server it will be set to
"private" and not show in the listing.

Note that privacy is not enforced on the download - if you know the URL
you can get the package, regardless of the visibility setting.