### PR TITLE
SubjectAltName for -DNS networks

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,14 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
  - Allowing for a proper shutdown from SIGTERM
 
-## [0.8.2] - 2021-09-03
-
-### Fixed
- - Routing GeoChats should work now
-
-### Contributors
- - Thanks to @skadakar for his work finding this, and testing the fix!
-
 ## [0.8.1] - 2021-06-06
 
 ### Fixed

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
  - Allowing for a proper shutdown from SIGTERM
 
+## [0.8.2] - 2021-09-03
+
+### Fixed
+ - Routing GeoChats should work now
+
+### Contributors
+ - Thanks to @skadakar for his work finding this, and testing the fix!
+
 ## [0.8.1] - 2021-06-06
 
 ### Fixed

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Contributors
  - Thanks to @skadakar for his work finding this, and testing the fix!
 
+
 ## [0.8.1] - 2021-06-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -90,24 +90,31 @@ optional arguments:
 
 ```
 
-# Create a taky.conf file
-Copy the example file:
-
+### Run insecure taky on 0.0.0.0:8087
+This uses a default config (taky.conf) which will listen on localhost. Edit server_address in the .conf file to have this listen on another IP interface.
 ```
-cp taky.conf.sample taky.conf
-```
-
-# Run insecure taky on 0.0.0.0:8087
-$ taky
+$ taky -c taky.conf
 INFO:root:taky v0.7
 INFO:COTServer:Listening for tcp on :8087
 ```
 
-# Run secure SSL taky on 0.0.0.0:8089
-sudo takyctl setup.py --user=$USER
-$ taky
+### Run secure SSL taky on 0.0.0.0:8089
+This uses a default config (taky.ssl.conf) which will listen on localhost. Edit server_address in the .conf file to have this listen on another IP interface. The --server-address will default to the FQDN eg. localhost. You can override it with an IP.
+To create the SSL certificates a script is used which places them in /etc/taky/ssl by default. Your account must have read permission for this folder.
+
+For convenience, a  certificate data package can be generated for quick EUD setup. This will be **user.zip** in the current folder in this example:
+
+```
+$ sudo takyctl -c taky.ssl.conf setup --user=$USER --server-address=192.168.1.107
+Installing site to system
+ - Wrote /etc/taky/taky.conf
+ - Generating certificate authority
+ - Generating server certificate
+ - Changing ownership to thelovedoctor
+$ takyctl -c taky.ssl.conf build_client --dump_pem user
+$ taky -c taky.ssl.conf
 INFO:root:taky v0.7
-INFO:COTServer:Listening for tcp on :8087
+INFO:COTServer:Listening for tcp on :8089
 ```
 
 ## Deploying Taky

--- a/README.md
+++ b/README.md
@@ -88,7 +88,23 @@ optional arguments:
   -c CFG_FILE           Path to configuration file
   --version             show program's version number and exit
 
-# Run taky on 0.0.0.0:8087
+```
+
+# Create a taky.conf file
+Copy the example file:
+
+```
+cp taky.conf.sample taky.conf
+```
+
+# Run insecure taky on 0.0.0.0:8087
+$ taky
+INFO:root:taky v0.7
+INFO:COTServer:Listening for tcp on :8087
+```
+
+# Run secure SSL taky on 0.0.0.0:8089
+sudo takyctl setup.py --user=$USER
 $ taky
 INFO:root:taky v0.7
 INFO:COTServer:Listening for tcp on :8087

--- a/doc/README_QUICKSTART.md
+++ b/doc/README_QUICKSTART.md
@@ -1,8 +1,23 @@
+
+# Do you need a server *now*?
+If you are not interested in manually creating certificates **but want a server now**, run the ./servernow.sh script located in ./taky/util/servernow.sh.
+
+This will generate 10 year certificates, an SSL server config with mutual authentication and an IP based (vs domain name based) server in /tmp/takyserver listening on SSL :8089
+
+The .zip data package(s) for clients will be offered via a web server on TCP:1664 for a 15 minute window. *If you miss the provisioning window you can sideload the .zip.*
+
+To add a client in ATAK, click "Import Manager" then "HTTP URL" and enter the http:// URL for your .zip which will be shown in the console.
+
+Download the .zip and expect to see a red "server disconnected" icon appear.
+Visit settings > Network connections and enable the server by checking the box.
+
+[2 minute TAK server on Youtube](https://www.youtube.com/watch?v=SRpU5w6VgDY)
+
 # Shut up and take my money!
 
 Ok, geez! Hold your horses! This guide assumes:
 
-1. You have sudo privilegs
+1. You have sudo privileges
 2. You don't mind installing things globally
 3. You don't want to run the server as root
 4. You want SSL, and know how to get files to your end user devices
@@ -61,6 +76,7 @@ $ python3 -m http.server
 Serving HTTP on 0.0.0.0 port 8000 (http://0.0.0.0:8000/) ...
 ```
 
+
 ## I want to delete everything and start over!
 
 Pretty simple.
@@ -78,3 +94,4 @@ Then, delete all the config and user data.
 ```
 root # rm -rf /etc/taky /var/taky
 ```
+

--- a/taky.conf
+++ b/taky.conf
@@ -1,0 +1,45 @@
+[taky]
+# Server Address
+# The public IP address, hostname, or FQDN. (Defaults to FQDN)
+#server_address=taky.local
+# The TAK Server nodeId
+#node_id=TAKY
+# The IP to bind to. Defaults to 0.0.0.0. To use IPv6, set to "::"
+#bind_ip=
+
+[cot_server]
+# If left blank, taky will listen on 8087 without SSL, or 8089 with SSL
+#port=
+# Where to store a log of .cot messages from the client for debug purposes
+#log_cot=
+
+[dp_server]
+# Where user datapackage uploads are stored.
+# For quick testing, set to /tmp/taky
+#upload_path=/var/taky/dp-user
+
+[ssl]
+# SSL is disabled by default. Set enabled to "true" to enable
+#enabled=false
+
+# Should taky require clients to have a certificate?
+#client_cert_required=false
+
+# The server certificate or certificate+keyfile
+#cert=/etc/taky/ssl/server.crt
+
+# Specify the SSL key path
+#key=/etc/taky/ssl/server.key
+
+# Specify the SSL key password (if required)
+#key_pw=
+
+# Specify an explicit CA certificate
+# If left blank, will use system CA certificates
+#ca=/etc/taky/ssl/ca.crt
+
+# If you want to use takyctl's build_client, you'll need to specify the
+# following items. (`takyctl setup` will build these for you!)
+#ca_key=/etc/taky/ssl/ca.key
+#server_p12=/etc/taky/ssl/server.p12
+#server_p12_key=atakatak

--- a/taky.ssl.conf
+++ b/taky.ssl.conf
@@ -1,0 +1,45 @@
+[taky]
+# Server Address
+# The public IP address, hostname, or FQDN. (Defaults to FQDN)
+server_address=192.168.1.107
+# The TAK Server nodeId
+#node_id=TAKY
+# The IP to bind to. Defaults to 0.0.0.0. To use IPv6, set to "::"
+#bind_ip=
+
+[cot_server]
+# If left blank, taky will listen on 8087 without SSL, or 8089 with SSL
+#port=
+# Where to store a log of .cot messages from the client for debug purposes
+#log_cot=
+
+[dp_server]
+# Where user datapackage uploads are stored.
+# For quick testing, set to /tmp/taky
+#upload_path=/var/taky/dp-user
+
+[ssl]
+# SSL is disabled by default. Set enabled to "true" to enable
+enabled=true
+
+# Should taky require clients to have a certificate?
+client_cert_required=true
+
+# The server certificate or certificate+keyfile
+cert=/etc/taky/ssl/server.crt
+
+# Specify the SSL key path
+key=/etc/taky/ssl/server.key
+
+# Specify the SSL key password (if required)
+#key_pw=
+
+# Specify an explicit CA certificate
+# If left blank, will use system CA certificates
+#ca=/etc/taky/ssl/ca.crt
+
+# If you want to use takyctl's build_client, you'll need to specify the
+# following items. (`takyctl setup` will build these for you!)
+ca_key=/etc/taky/ssl/ca.key
+server_p12=/etc/taky/ssl/server.p12
+server_p12_key=atakatak

--- a/taky/cli/build_client_cmd.py
+++ b/taky/cli/build_client_cmd.py
@@ -81,7 +81,9 @@ def build_client(args):
         },
     }
 
+
     with open(os.path.join(cdir, "preference.pref"), "wb") as pref_fp:
+
         datapackage.build_pref(pref_fp, prefs)
 
     # Build Mission Package Manifest
@@ -90,6 +92,7 @@ def build_client(args):
         "name": f"{server_addr}_DP",
         "onReceiveDelete": "true",
     }
+
     man_cts = ["preference.pref", server_p12_pkg_name, f"{client_pkg_name}.p12"]
 
     with open(os.path.join(mdir, "manifest.xml"), "wb") as man_fp:

--- a/taky/cli/setup_taky_cmd.py
+++ b/taky/cli/setup_taky_cmd.py
@@ -11,6 +11,7 @@ import taky.util.rotc as rotc
 def setup_taky_reg(subp):
     try:
         default_hostname = socket.getfqdn()
+
     except:  # pylint: disable=bare-except
         default_hostname = "taky"
 
@@ -66,13 +67,13 @@ def setup_taky(args):
         ssl_path = "ssl"
         config_path = "taky.conf"
 
-        config.set("ssl", "ca", os.path.join(".", "ssl", "ca.crt"))
-        config.set("ssl", "ca_key", os.path.join(".", "ssl", "ca.key"))
-        config.set("ssl", "server_p12", os.path.join(".", "ssl", "server.p12"))
-        config.set("ssl", "cert", os.path.join(".", "ssl", "server.crt"))
-        config.set("ssl", "key", os.path.join(".", "ssl", "server.key"))
+        config.set("ssl", "ca", os.path.join(args.path, "ssl", "ca.crt"))
+        config.set("ssl", "ca_key", os.path.join(args.path, "ssl", "ca.key"))
+        config.set("ssl", "server_p12", os.path.join(args.path, "ssl", "server.p12"))
+        config.set("ssl", "cert", os.path.join(args.path, "ssl", "server.crt"))
+        config.set("ssl", "key", os.path.join(args.path, "ssl", "server.key"))
 
-        config.set("dp_server", "upload_path", os.path.join(".", "dp-user"))
+        config.set("dp_server", "upload_path", os.path.join(args.path, "dp-user"))
     else:
         print("Installing site to system")
         args.path = "/"

--- a/taky/cli/setup_taky_cmd.py
+++ b/taky/cli/setup_taky_cmd.py
@@ -140,7 +140,7 @@ def setup_taky(args):
         rotc.make_cert(
             path=ssl_path,
             f_name="server",
-            hostname=args.hostname,
+            hostname=args.server_address,
             cert_pw=args.p12_pw,  # TODO: OS environ? -p is bad
             cert_auth=(config.get("ssl", "ca"), config.get("ssl", "ca_key")),
             dump_pem=True,

--- a/taky/config.py
+++ b/taky/config.py
@@ -5,6 +5,8 @@ import socket
 
 app_config = configparser.ConfigParser(allow_no_value=True)
 
+app_config = configparser.ConfigParser(allow_no_value=True)
+
 DEFAULT_CFG = {
     "taky": {
         "node_id": "TAKY",  # TAK Server nodeId
@@ -54,16 +56,15 @@ def load_config(path=None, explicit=False):
 
     if explicit and not os.path.exists(path):
         raise FileNotFoundError("Config file required, but not present")
-
     ret_config = configparser.ConfigParser(allow_no_value=True)
     ret_config.read_dict(DEFAULT_CFG)
-
     lgr = logging.getLogger("load_config")
 
     if os.path.exists(path):
         lgr.info("Loading config file from %s", path)
         with open(path, "r") as cfg_fp:
             ret_config.read_file(cfg_fp, source=path)
+
 
     # TODO: Deprecate
     if ret_config.has_option("taky", "hostname") or ret_config.has_option(
@@ -82,6 +83,7 @@ def load_config(path=None, explicit=False):
     else:
         hostname = socket.getfqdn()
     ret_config.set("taky", "server_address", hostname)
+
 
     port = ret_config.get("cot_server", "port")
     if port in [None, ""]:

--- a/taky/cot/client.py
+++ b/taky/cot/client.py
@@ -110,8 +110,7 @@ class SocketClient:
             self.feed(data)
         except etree.XMLSyntaxError as exc:
             self.disconnect(str(exc))
-        except (ssl.SSLError, socket.error, IOError, OSError) as exc:
-            self.disconnect(str(exc))
+
 
     def socket_tx(self):
         """
@@ -152,6 +151,7 @@ class TAKClient:
     """
 
     def __init__(self, router=None, log_cot_dir=None, **kwargs):
+
         self.router = router
         self.user = None
         self.connected = time.time()
@@ -335,7 +335,6 @@ class SocketTAKClient(TAKClient, SocketClient):
             f"addr={self.addr[0]}:{self.addr[1]}>"
         )
 
-
     def send_event(self, event, src=None):
         """
         Send a CoT event to the client. Data should be a cot Event object,
@@ -363,3 +362,4 @@ class SocketTAKClient(TAKClient, SocketClient):
             self.out_buff += data
         else:
             raise ValueError("Can only send Event / XML to TAKClient!")
+

--- a/taky/cot/router.py
+++ b/taky/cot/router.py
@@ -59,6 +59,7 @@ class COTRouter:
 
             client.send_event(event)
 
+
     def find_clients(self, uid=None, callsign=None):
         """
         Returns an iterator of objects matching the criteria
@@ -71,6 +72,7 @@ class COTRouter:
                 yield client
             if callsign and client.user.callsign == callsign:
                 yield client
+
 
     def broadcast(self, src, msg):
         """
@@ -123,6 +125,7 @@ class COTRouter:
         """
         for client in self.find_clients(uid=dst_uid, callsign=dst_cs):
             client.send_event(msg, src)
+
 
     def route(self, src, evt):
         """

--- a/taky/cot/router.py
+++ b/taky/cot/router.py
@@ -122,7 +122,7 @@ class COTRouter:
         Send a message to a destination by callsign or UID
         """
         for client in self.find_clients(uid=dst_uid, callsign=dst_cs):
-            client.send_event(msg)
+            client.send_event(msg, src)
 
     def route(self, src, evt):
         """

--- a/taky/cot/server.py
+++ b/taky/cot/server.py
@@ -56,9 +56,8 @@ class COTServer:
         self.mon = None
         self.srv = None
         self.ssl_ctx = None
-
         self.started = -1
-
+        
     def sock_setup(self):
         """
         Build the server socket
@@ -135,6 +134,22 @@ class COTServer:
         """
         Accept a new client on the management socket
         """
+        try:
+            (sock, _) = self.mgmt.accept()
+        except (socket.error, OSError) as exc:
+            self.lgr.info("Dropping management client: %s", exc)
+            return
+
+        self.lgr.info("New management client")
+        self.clients[sock] = MgmtClient(sock=sock, use_ssl=False, server=self)
+
+    def srv_accept(self, sock, force_tcp=False):
+        """
+        Accept a new client from a server socket
+        """
+        ip_addr = None
+        port = None
+
         try:
             (sock, _) = self.mgmt.accept()
         except (socket.error, OSError) as exc:

--- a/taky/cot/server.py
+++ b/taky/cot/server.py
@@ -157,11 +157,18 @@ class COTServer:
             stype = "tcp"
 
             if self.ssl_ctx and not force_tcp:
-                sock = self.ssl_ctx.wrap_socket(
-                    sock, server_side=True, do_handshake_on_connect=False
-                )
-                sock.setblocking(False)
+                if self.ssl_ctx.verify_mode == ssl.CERT_REQUIRED:
+                    sock = self.ssl_ctx.wrap_socket(
+                        sock, server_side=True, do_handshake_on_connect=True
+                    )
+                    clientCert = sock.getpeercert()
+                    self.lgr.debug("Client cert: {}".format(clientCert))
+                else:
+                    sock = self.ssl_ctx.wrap_socket(
+                        sock, server_side=True, do_handshake_on_connect=False
+                    )
                 stype = "ssl"
+
         except ssl.SSLError as exc:
             self.lgr.info("Rejecting client %s:%s (%s)", ip_addr, port, exc)
         except (socket.error, OSError) as exc:

--- a/taky/util/dpserver.py
+++ b/taky/util/dpserver.py
@@ -1,0 +1,41 @@
+#!/usr/bin/python3
+from flask import Flask, request, send_from_directory
+import sys
+import os
+import socket
+import random
+
+# Serves certificates from /tmp/taky_dp
+# eg. http://192.168.1.107:1664/5036307/user_DP.zip
+
+app = Flask(__name__, static_url_path='')
+port = 1664
+
+if len(sys.argv) < 2:
+  print("Need a directory to serve up. eg. dpserver.py /tmp/somedir")
+  quit()
+
+webroot = os.path.join(os.getcwd(), sys.argv[1])
+
+if not os.path.exists(webroot):
+  print("Folder %s does not exist" % webroot)
+  quit()
+
+
+nonce = "takycerts" # str(random.randrange(1e6,10e6)) # Make URL harder to guess 
+
+@app.route("/"+nonce+"/<path>")
+def send_js(path):
+    return send_from_directory(webroot, path)
+  
+
+if __name__ == "__main__":
+    print("\nWARNING: Serving certificates insecurely from %s" % webroot)
+    files = os.listdir(webroot)
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.connect(("8.8.8.8", 53)) # to resolve our external IP. Doesn't have to be reachable.
+    ip = s.getsockname()[0]
+    for f in files:
+      print("http://%s:%d/%s/%s" % (ip,port,nonce,f))
+
+    app.run(host="0.0.0.0",port=port)

--- a/taky/util/rotc.py
+++ b/taky/util/rotc.py
@@ -23,7 +23,7 @@ def make_ca(crt_path, key_path, n_years=10):
     ca_key.generate_key(crypto.TYPE_RSA, 2048)
 
     cert = crypto.X509()
-    cert.get_subject().CN = "CA"
+    cert.get_subject().CN = "TAKY CA"
     cert.set_serial_number(0)
     cert.set_version(2)
     cert.gmtime_adj_notBefore(0)
@@ -84,7 +84,7 @@ def make_cert(path, f_name, hostname, cert_pw, cert_auth, n_years=10, dump_pem=F
     cert.gmtime_adj_notBefore(0)
     cert.gmtime_adj_notAfter(31536000 * n_years)
     cert.set_issuer(capem.get_subject())
-    
+
     # SAN is checked for https:// links
     if hostname[:2].isnumeric():
         subjectAltName = b"IP.1:"+hostname.encode()
@@ -98,7 +98,6 @@ def make_cert(path, f_name, hostname, cert_pw, cert_auth, n_years=10, dump_pem=F
     cert.set_pubkey(cli_key)
     cert.set_version(2)
     cert.sign(cakey, "sha256")
-
     p12 = crypto.PKCS12()
     p12.set_privatekey(cli_key)
     p12.set_certificate(cert)

--- a/taky/util/rotc.py
+++ b/taky/util/rotc.py
@@ -84,6 +84,17 @@ def make_cert(path, f_name, hostname, cert_pw, cert_auth, n_years=10, dump_pem=F
     cert.gmtime_adj_notBefore(0)
     cert.gmtime_adj_notAfter(31536000 * n_years)
     cert.set_issuer(capem.get_subject())
+    
+    # SAN is checked for https:// links
+    if hostname[:2].isnumeric():
+        subjectAltName = b"IP.1:"+hostname.encode()
+    else:
+        subjectAltName = b"DNS:"+hostname.encode()
+    cert.add_extensions(
+        [
+            crypto.X509Extension(b'subjectAltName', False, subjectAltName)
+        ]
+    )
     cert.set_pubkey(cli_key)
     cert.set_version(2)
     cert.sign(cakey, "sha256")

--- a/taky/util/servernow.sh
+++ b/taky/util/servernow.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# 
+# Builds a secure taky server now, not next week.
+
+NIC=`route -n | grep '0.0.0.0' | head -1 |  awk '{print $8}'`
+IP=`ifconfig $NIC | grep 'inet ' | awk '{print $2}'`
+#IP=90.216.1.129
+TAKY_SERVER="/tmp/takyserver"
+
+takyctl setup --public-ip $IP --host $IP $TAKY_SERVER
+takyctl -c $TAKY_SERVER/taky.conf build_client --dump_pem user
+mkdir $TAKY_SERVER/taky_dp
+cp user.zip $TAKY_SERVER/taky_dp
+cp user.* $TAKY_SERVER/ssl
+
+# Comment this line to NOT serve your certificates insecurely via HTTP :1664
+# It will serve the certs for 15 minutes only. After that you need to sideload the .zip
+timeout 15m python3 dpserver.py $TAKY_SERVER/taky_dp &
+taky -c $TAKY_SERVER/taky.conf
+

--- a/version.txt
+++ b/version.txt
@@ -1,3 +1,0 @@
-owner: Cloud-RF
-product: taky (public fork)
-version: 1.0-DEV

--- a/version.txt
+++ b/version.txt
@@ -1,0 +1,3 @@
+owner: Cloud-RF
+product: taky (public fork)
+version: 1.0-DEV


### PR DESCRIPTION
Tested with ATAK 4.4.0.6 and custom CoT/SSL clients.

- SAN for certs with an IP address eg. https://192.168.1.1
- New .conf examples for vanilla TCP and SSL setups
- Debug info for client certificate
- Fixed setup_taky_cmd server_name
- whois extension for anon shapes
- README updated with more examples
