### PR TITLE
KML output #27 and fixed some setup issues

### DIFF
--- a/doc/README_DEPLOYMENT.md
+++ b/doc/README_DEPLOYMENT.md
@@ -115,7 +115,7 @@ This step will also generate the certificate authority, and server certificate.
 `bin/activate` file!)
 
 ```
-admin@bluetack:~$ sudo taky --user stickytak \
+admin@bluetack:~$ sudo takyctl setup --user stickytak \
                             --server-address 192.168.1.100
 
 admin@bluetack:~$ ls -l /etc/taky
@@ -139,6 +139,7 @@ node_id = TAKY
 bind_ip = 0.0.0.0
 server_address = 192.168.1.100
 redis
+root_dir=/tmp
 
 [cot_server]
 port = 8089

--- a/doc/README_QUICKSTART.md
+++ b/doc/README_QUICKSTART.md
@@ -2,7 +2,7 @@
 
 Ok, geez! Hold your horses! This guide assumes:
 
-1. You have sudo privilegs
+1. You have sudo privileges
 2. You don't mind installing things globally
 3. You don't want to run the server as root
 4. You want SSL, and know how to get files to your end user devices

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Flask
 pyopenssl
 gunicorn
 redis
+simplekml

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author="Tim K",
     author_email="tpkuester@gmail.com",
     setup_requires=["setuptools_scm"],
-    install_requires=["lxml", "dateutils", "Flask", "pyopenssl", "gunicorn", "redis"],
+    install_requires=["lxml", "dateutils", "Flask", "pyopenssl", "gunicorn", "redis", "simplekml"],
     description="A simple TAK server and COT router",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/taky.conf.sample
+++ b/taky.conf.sample
@@ -1,7 +1,8 @@
 [taky]
 # Server Address
 # The public IP address, hostname, or FQDN. (Defaults to FQDN)
-#server_address=taky.local
+server_address=127.0.0.1
+root_dir=/tmp
 # The TAK Server nodeId
 #node_id=TAKY
 # The IP to bind to. Defaults to 0.0.0.0. To use IPv6, set to "::"

--- a/taky/cli/mgmt_cmds.py
+++ b/taky/cli/mgmt_cmds.py
@@ -3,6 +3,7 @@ import sys
 import time
 import socket
 import json
+import simplekml
 from collections import namedtuple
 
 from taky.util import pprinttable, seconds_to_human
@@ -28,6 +29,14 @@ def mgmt_reg(subp, cmd_name, cmd_help):
         help="Output the status in JSON",
     )
 
+    argp.add_argument(
+        "-k",
+        "--kml",
+        dest="kml",
+        default=False,
+        action="store_true",
+        help="Output the status in KML",
+    )
 
 def print_status(stat):
     print("Version: %s" % stat.get("version"))
@@ -112,6 +121,8 @@ def mgmt_cmd(args, command, callback):
 
         if args.json:
             print(json.dumps(stat))
+        elif args.kml:
+            print(kml(stat))
         else:
             callback(stat)
     except (UnicodeDecodeError, json.JSONDecodeError) as exc:
@@ -144,3 +155,17 @@ def mgmt_purge_persist(args):
         print("%d items deleted" % data.get("purged", 0))
 
     return mgmt_cmd(args, "purge_persist", cb)
+
+# Print KML to stdout
+def kml(stat):
+    kml = simplekml.Kml()
+    clients = stat.get("clients")
+    
+    # FAQ: https://simplekml.readthedocs.io/en/latest/styling.html
+    for c in clients:
+      pnt = kml.newpoint(name=c["callsign"])
+      pnt.description = "<pre>"+json.dumps(c,sort_keys=True, indent=2)+"</pre>"
+      pnt.coords = [(c["lon"],c["lat"])]
+      
+    return kml.kml()
+

--- a/taky/cli/setup_taky_cmd.py
+++ b/taky/cli/setup_taky_cmd.py
@@ -109,6 +109,8 @@ def setup_taky(args):
 
     if args.user:
         shutil.chown(config_path, user=args.user, group=args.user)
+        root_dir = config.get("taky", "root_dir")
+        shutil.chown(root_dir, user=args.user, group=args.user)
 
     dirs = [
         config.get("dp_server", "upload_path"),
@@ -140,7 +142,7 @@ def setup_taky(args):
         rotc.make_cert(
             path=ssl_path,
             f_name="server",
-            hostname=args.hostname,
+            hostname=args.server_address,
             cert_pw=args.p12_pw,  # TODO: OS environ? -p is bad
             cert_auth=(config.get("ssl", "ca"), config.get("ssl", "ca_key")),
             dump_pem=True,

--- a/taky/cot/client.py
+++ b/taky/cot/client.py
@@ -173,6 +173,7 @@ class TAKClient:
 
         self.log_cot_dir = log_cot_dir
         self.cot_fp = None
+        self.evt = None # To get the <point>
 
         parser = etree.XMLPullParser(tag="event", resolve_entities=False)
         parser.feed(b"<root>")
@@ -277,6 +278,7 @@ class TAKClient:
 
                 self.router.route(self, evt)
                 self.log_event(evt)
+                self.evt = evt
             except models.UnmarshalError as exc:
                 self.lgr.debug("Unable to parse Event: %s", exc, exc_info=exc)
                 self.lgr.debug(etree.tostring(elm, pretty_print=True))

--- a/taky/cot/mgmt.py
+++ b/taky/cot/mgmt.py
@@ -66,7 +66,7 @@ class MgmtClient(SocketClient):
         for client in self.server.clients.values():
             if not isinstance(client, TAKClient):
                 continue
-
+            
             ret["num_clients"] += 1
             cli_meta = {
                 "last_rx": client.last_rx,
@@ -86,6 +86,9 @@ class MgmtClient(SocketClient):
                 cli_meta["os"] = client.user.device.os
                 cli_meta["version"] = client.user.device.version
                 cli_meta["platform"] = client.user.device.platform
+            if client.evt: 
+                cli_meta["lat"] = client.evt.point.lat
+                cli_meta["lon"] = client.evt.point.lon                
             else:
                 cli_meta["anonymous"] = True
 


### PR DESCRIPTION
#27 
KML output for `takyctl status -k`
Can be piped to a file on a web server for an auto-updating network KML eg. 
`while true; do takyctl status -k > /var/www/html/atak_server.kml; sleep 5; done`

Setup issues fixed:

- example conf fails due to missing root_dir, have used /tmp
- deployment docs appear to have incorrect takyctl setup command
- setup_taky_cmd.py referencing legacy args.hostname
- setup_taky_cmd.py did not chown root_dir to $USER
