### PR TITLE
FEAT: Opex attribute of CoT Event

### DIFF
--- a/taky/cot/models/event.py
+++ b/taky/cot/models/event.py
@@ -20,6 +20,7 @@ class Event:
         start=None,
         stale=None,
         version="2.0",
+        opex=None,
     ):
         self.version = version
         self.uid = uid
@@ -28,6 +29,7 @@ class Event:
         self.time = time
         self.start = start
         self.stale = stale
+        self.opex = opex
 
         self.point = Point()
         self.detail = None
@@ -63,6 +65,7 @@ class Event:
             time=time,
             start=start,
             stale=stale,
+            opex=elm.get("opex"),
         )
 
         if ret.uid is None:
@@ -101,6 +104,10 @@ class Event:
         ret.set("time", self.time.isoformat(timespec="milliseconds") + "Z")
         ret.set("start", self.start.isoformat(timespec="milliseconds") + "Z")
         ret.set("stale", self.stale.isoformat(timespec="milliseconds") + "Z")
+
+        if self.opex is not None:
+            ret.set("opex", self.opex)
+
         ret.append(self.point.as_element)
         if self.detail is not None:
             ret.append(self.detail.as_element)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,10 +2,11 @@ import queue
 
 from taky import cot
 
-XML_S = b"""<event version="2.0" uid="ANDROID-deadbeef" type="a-f-G-U-C" how="m-g" time="2021-02-27T20:32:24.771Z" start="2021-02-27T20:32:24.771Z" stale="2021-02-27T20:38:39.771Z"><point lat="1.234567" lon="-3.141592" hae="-25.7" ce="9.9" le="9999999.0"/><detail><takv os="29" version="4.0.0.0 (deadbeef).1234567890-CIV" device="Some Android Device" platform="ATAK-CIV"/><contact xmppUsername="xmpp@host.com" endpoint="*:-1:stcp" callsign="JENNY"/><uid Droid="JENNY"/><precisionlocation altsrc="GPS" geopointsrc="GPS"/><__group role="Team Member" name="Cyan"/><status battery="78"/><track course="80.24833892285461" speed="0.0"/></detail></event>"""
+XML_S = b"""<event version="2.0" uid="ANDROID-deadbeef" type="a-f-G-U-C" how="m-g" time="2021-02-27T20:32:24.771Z" start="2021-02-27T20:32:24.771Z" stale="2021-02-27T20:38:39.771Z" opex="foo"><point lat="1.234567" lon="-3.141592" hae="-25.7" ce="9.9" le="9999999.0"/><detail><takv os="29" version="4.0.0.0 (deadbeef).1234567890-CIV" device="Some Android Device" platform="ATAK-CIV"/><contact xmppUsername="xmpp@host.com" endpoint="*:-1:stcp" callsign="JENNY"/><uid Droid="JENNY"/><precisionlocation altsrc="GPS" geopointsrc="GPS"/><__group role="Team Member" name="Cyan"/><status battery="78"/><track course="80.24833892285461" speed="0.0"/></detail></event>"""
+XML_NO_OPEX = b"""<event version="2.0" uid="ANDROID-deadbeef" type="a-f-G-U-C" how="m-g" time="2021-02-27T20:32:24.771Z" start="2021-02-27T20:32:24.771Z" stale="2021-02-27T20:38:39.771Z"><point lat="1.234567" lon="-3.141592" hae="-25.7" ce="9.9" le="9999999.0"/><detail><takv os="29" version="4.0.0.0 (deadbeef).1234567890-CIV" device="Some Android Device" platform="ATAK-CIV"/><contact xmppUsername="xmpp@host.com" endpoint="*:-1:stcp" callsign="JENNY"/><uid Droid="JENNY"/><precisionlocation altsrc="GPS" geopointsrc="GPS"/><__group role="Team Member" name="Cyan"/><status battery="78"/><track course="80.24833892285461" speed="0.0"/></detail></event>"""
 
 XML_EMPTY_MARTI_BC = b"""
-<event version="2.0" uid="EB77220E-6299-4CA3-95FC-0200BD9FE78A" type="a-u-G" how="h-g-i-g-o" time="2023-01-12T09:53:31.000Z" start="2023-01-12T09:53:31.000Z" stale="2023-01-12T09:55:31.000Z">
+<event version="2.0" uid="EB77220E-6299-4CA3-95FC-0200BD9FE78A" type="a-u-G" how="h-g-i-g-o" time="2023-01-12T09:53:31.000Z" start="2023-01-12T09:53:31.000Z" stale="2023-01-12T09:55:31.000Z" opex="foo">
     <point lat="54.338986" lon="9.755263" hae="0.0" ce="0.0" le="0.0"/>
     <detail>
         <contact callsign="poop"/>

--- a/tests/test_cot_event.py
+++ b/tests/test_cot_event.py
@@ -3,7 +3,7 @@ import unittest as ut
 from lxml import etree
 
 from taky.cot import models
-from . import elements_equal, XML_S
+from . import elements_equal, XML_S, XML_NO_OPEX
 
 
 class COTTestcase(ut.TestCase):
@@ -19,6 +19,7 @@ class COTTestcase(ut.TestCase):
         self.assertEqual(event.etype, "a-f-G-U-C")
         self.assertEqual(event.how, "m-g")
         self.assertEqual(event.time, event.start)
+        self.assertEqual(event.opex, "foo")
 
         # Point
         self.assertAlmostEqual(event.point.lat, 1.234567, places=6)
@@ -37,6 +38,15 @@ class COTTestcase(ut.TestCase):
         elm = etree.fromstring(XML_S)
 
         self.assertTrue(elements_equal(elm, event.as_element))
+
+    def test_marshall_with_opex(self):
+        elmEvent = models.Event.from_elm(self.elm).as_element
+        self.assertEqual("foo", elmEvent.get("opex"))
+
+    def test_marshall_without_opex(self):
+        element = etree.fromstring(XML_NO_OPEX)
+        elmEvent = models.Event.from_elm(element).as_element
+        self.assertIsNone(elmEvent.get("opex"))
 
     def test_marshall_err_tagname(self):
         self.elm.tag = "xxx"


### PR DESCRIPTION
CoT Event objects contain an "opex" attribute. The "opex" attribute is only (un)marshalled when incoming CoT messages contain the attribute. Unit tests included verifying (un)marshalling the "opex" attribute.