### PR TITLE
Handle absent course and speed attributes

### DIFF
--- a/taky/cot/models/takuser.py
+++ b/taky/cot/models/takuser.py
@@ -88,8 +88,12 @@ class TAKUser(Detail):
             elif d_elm.tag == "status":
                 ret.battery = d_elm.get("battery")
             elif d_elm.tag == "track":
-                ret.course = float(d_elm.get("course"))
-                ret.speed = float(d_elm.get("speed"))
+                course_attr = d_elm.get("course")
+                speed_attr = d_elem.get("speed")
+                if course_attr != None:
+                    ret.course = float(course_attr)
+                if speed_attr != None:
+                    ret.speed = float(speed_attr)
 
         return ret
 


### PR DESCRIPTION
Some of our CoT payloads don't have course and speed attributes (actually they don't have a track element) in the detail element. This was causing an exception in `taky` and it wasn't propagating the packets to ATAK clients.

With this change, the packets propagate as we expect (and are used to from FTS).

However, if this is considered invalid CoT and acceptable to not handle, I am willing to withdraw the PR.