### PR TITLE
Add basic Dockerfile for building fixed version of Taky from tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ htmlcov
 *.pem
 *.p12
 *.zip
+.venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# First stage: builder
+FROM python:3.11 as builder
+
+ENV TAKY_VERSION=0.9
+
+WORKDIR /build
+
+RUN git clone --depth 1 https://github.com/tkuester/taky.git -b ${TAKY_VERSION}
+
+WORKDIR /build/taky
+
+RUN python3 -m pip install --upgrade pip && \
+    python3 -m pip install -r requirements.txt && \
+    python3 setup.py install && \
+    find /usr/local -name '*.pyc' -delete && \
+    find /usr/local -name '__pycache__' -type d -exec rm -rf {} +
+
+# Second stage: runtime
+FROM python:3.11-slim as runtime
+
+WORKDIR /
+
+COPY --from=builder /usr/local /usr/local
+
+RUN mkdir -p /var/taky
+
+ENTRYPOINT [ "taky", "-c", "/taky/taky.conf" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 FROM python:3.11 as builder
 
 ENV TAKY_VERSION=0.9
+ENV PUBLIC_IP=192.168.0.60
 
 WORKDIR /build
 
@@ -15,13 +16,16 @@ RUN python3 -m pip install --upgrade pip && \
     find /usr/local -name '*.pyc' -delete && \
     find /usr/local -name '__pycache__' -type d -exec rm -rf {} +
 
+RUN takyctl setup --public-ip=${PUBLIC_IP} /etc/taky
+
 # Second stage: runtime
 FROM python:3.11-slim as runtime
 
 WORKDIR /
 
+RUN mkdir /var/taky
+
 COPY --from=builder /usr/local /usr/local
+COPY --from=builder /etc/taky /etc/taky
 
-RUN mkdir -p /var/taky
-
-ENTRYPOINT [ "taky", "-c", "/taky/taky.conf" ]
+ENTRYPOINT [ "taky", "-c", "/etc/taky/taky.conf" ]


### PR DESCRIPTION
This PR adds a Dockerfile to the project which can build Taky from source based on a GitHub tag. This can be expanded later, and I will look to also add a GitHub build and push action on tags.