### PR TITLE
Allow user to upload datapackages when not using SSL

### DIFF
--- a/taky/dps/__init__.py
+++ b/taky/dps/__init__.py
@@ -9,10 +9,14 @@ from taky.config import load_config, app_config
 application = app = Flask(__name__)
 
 
-def requires_auth(func):
+def requires_auth(func, config):
     """
-    Function to ensure that a valid client certificate is submitted
+    Function to ensure that a valid client certificate is submitted if SSL is enabled
     """
+
+	
+    if config.getboolean("ssl", "enabled"):
+        return check_headers
 
     @functools.wraps(func)
     def check_headers(*args, **kwargs):
@@ -23,7 +27,6 @@ def requires_auth(func):
 
         return func(*args, **kwargs)
 
-    return check_headers
 
 
 def configure_app(config):

--- a/taky/dps/views/datapackage.py
+++ b/taky/dps/views/datapackage.py
@@ -42,6 +42,9 @@ def put_meta(meta):
 
     # Save the file's meta/{filename}.json
     meta_path = os.path.join(app.config["UPLOAD_PATH"], "meta", f"{filename}.json")
+    # Create directories if they do not exist
+    os.makedirs(os.path.dirname(meta_path), exist_ok=True)
+    
     with open(meta_path, "w", encoding="utf8") as meta_fp:
         json.dump(meta, meta_fp)
 
@@ -135,8 +138,12 @@ def datapackage_upload():
         except:  # pylint: disable=bare-except
             pass
 
+    
     # Save the uploaded file
     file_path = os.path.join(app.config["UPLOAD_PATH"], filename)
+    
+    # Create the directory if it doesn't exist 
+    os.makedirs(os.path.dirname(file_path), exist_ok=True)
     asset_fp.save(file_path)
 
     sub_user = request.headers.get("X-USER", "Anonymous")


### PR DESCRIPTION
This PR seeks to fix #92 where users cannot upload datapackages when the server is configured to use the TCP streaming protocol.

Confirmed working while running `taky_deps` on the command line and when installed as a systemctl service. I have not tested it with SSL on, as generating SSL certs are broken on Ubuntu >22.04. 

Thank you @tkuester.