### PR TITLE
Path fix

### DIFF
--- a/taky/cot/client.py
+++ b/taky/cot/client.py
@@ -13,6 +13,7 @@ from lxml import etree
 
 from taky.config import app_config
 from taky.util import XMLDeclStrip
+from taky import util
 from . import models
 
 
@@ -246,6 +247,8 @@ class TAKClient:
 
             try:
                 self.lgr.debug("Opening logfile %s", name)
+                if not util.is_file_safe(name,self.log_cot_dir):
+                    raise OSError(f"Illegal file path {name}" )
                 self.cot_fp = open(name, "a+", encoding="utf8")
             except OSError as exc:
                 self.lgr.warning("Unable to open COT log: %s", exc)

--- a/taky/util/__init__.py
+++ b/taky/util/__init__.py
@@ -61,3 +61,12 @@ def pprinttable(rows):
     print(separator)
     for line in rows:
         print(pattern % tuple(t for t in line))
+
+
+def is_file_safe(file_name, dir_path):
+    """
+    Ensure that path traversal is not possible
+    """
+    file_path = os.path.dirname(file_name)
+    real_dir = os.path.realpath(file_path)
+    return os.path.realpath(dir_path) == real_dir


### PR DESCRIPTION
The file names are generated from client defined input. To eliminate directory traversal a check is made to ensure that files stay in the right folder.