### PR TITLE
Add support for iTAK-specific routing by uid

### DIFF
--- a/taky/cot/models/detail.py
+++ b/taky/cot/models/detail.py
@@ -46,7 +46,26 @@ class Detail:
             return
 
         for dest in marti.iterfind("dest"):
-            yield dest.get("callsign")
+            if dest.get("callsign") is not None:
+                yield dest.get("callsign")
+                
+    @property
+    def marti_uid(self):
+        """
+        A list of UIDs in the Marti tag (if present)
+
+        Returns an empty list if not present
+        """
+        if self.elm is None:
+            return
+
+        marti = self.elm.find("marti")
+        if marti is None:
+            return
+
+        for dest in marti.iterfind("dest"):
+            if dest.get("uid") is not None:
+                yield dest.get("uid")
 
     @property
     def as_element(self):


### PR DESCRIPTION
# Description

iTAK seems to send position points and other such objects to others by UIDs, instead of callsigns. Added that support to the router, so that iTAK clients can exchange these with others. Together with #99, this should make iTAK minimally usable with taky for basic positional information exchange.