### PR TITLE
Fix cast to string

### DIFF
--- a/taky/cli/systemd_cmd.py
+++ b/taky/cli/systemd_cmd.py
@@ -163,7 +163,7 @@ def systemd(args):
             "dps": "taky-dps.service",
         }
     else:
-        site_path = os.path.dirname(config.get("taky", "cfg_path"))
+        site_path = os.path.dirname(str(config.get("taky", "cfg_path")))
         hostname = config.get("taky", "hostname")
         print(f" - Detected site install: {site_path}")
         svcs = {


### PR DESCRIPTION
A missing cast to string was causing a cash in while builing the systemd file.

Stacktracke:

```
Building systemd services
systemd failed: expected str, bytes or os.PathLike object, not NoneType
Unhandled exception:
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/taky/cli/__main__.py", line 51, in main
    ret = commands[args.command](args)
  File "/usr/local/lib/python3.10/dist-packages/taky/cli/systemd_cmd.py", line 166, in systemd
    site_path = os.path.dirname(config.get("taky", "cfg_path"))
  File "/usr/lib/python3.10/posixpath.py", line 152, in dirname
    p = os.fspath(p)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```
